### PR TITLE
Revisited the build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -72,6 +72,7 @@ EDITOR=true "$DT_ROOT/gn" args "out/$DEPS_CONFIG" --args="is_debug=$DAWN_IS_DEBU
 "$DT_ROOT/ninja" -C "out/$DEPS_CONFIG"
 cp -R src/include/* $DEPS_INCLUDE_FOLDER
 cp -R out/$DEPS_CONFIG/gen/src/include/* $DEPS_INCLUDE_FOLDER
+cp -R third_party/glfw/include/* $DEPS_INCLUDE_FOLDER
 
 cp out/$DEPS_CONFIG/obj/libdawn_native.a $DEPS_LIB_FOLDER
 cp out/$DEPS_CONFIG/obj/libdawn_wire.a $DEPS_LIB_FOLDER


### PR DESCRIPTION
@isaacbrodsky I made the updates we discussed earlier. I initially tried getting `arrow` into `vcpkg` install directory, but I couldn't get linking to work properly, so I went with the solution that flattens the directory structure and puts everything in one place. Include/link paths should be dead-simple to specify now, and I'm about to give these a try in the revisited cmake setup.

Let me know if you see any issues with having this type of structure. If not, let's run these on Linux and merge those in