### PR TITLE
Fixed cmake lib lookup

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -10,11 +10,11 @@ set(ALL_SOURCE_FILES
     test.cpp
     )
 
-add_executable(example ${ALL_SOURCE_FILES})
-
 include_directories(${DEPS_ROOT}/include)
-find_library(jsoncpp_LIB libjsoncpp.a PATHS ${DEPS_ROOT}/lib)
-find_library(gtest_LIB libgtest.a PATHS ${DEPS_ROOT}/lib)
+find_library(jsoncpp_LIB jsoncpp PATHS ${DEPS_ROOT}/lib NO_DEFAULT_PATH)
+find_library(gtest_LIB gtest PATHS ${DEPS_ROOT}/lib NO_DEFAULT_PATH)
+
+add_executable(example ${ALL_SOURCE_FILES})
 target_link_libraries(example PUBLIC ${jsoncpp_LIB} ${gtest_LIB} pthread)
 
 # Testing


### PR DESCRIPTION
`gtest` lib that was being found by `find_library` for `example` executable seemed to be the system installed library which crashed for some reason. Made `find_library` ignore default paths, and explicitly use the one we specify as documented [here](https://cmake.org/cmake/help/latest/command/find_library.html)